### PR TITLE
Add return type hints

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -16,10 +16,8 @@ class Configuration implements ConfigurationInterface
 {
     /**
      * Generates the configuration tree builder.
-     *
-     * @return TreeBuilder The tree builder
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         if (Kernel::VERSION_ID >= 40200) {
             $treeBuilder = new TreeBuilder('jb_phumbor');
@@ -51,8 +49,6 @@ class Configuration implements ConfigurationInterface
 
     /**
      * Add the transformation section configuration structure
-     *
-     * @param \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $rootNode
      */
     private function addTransformationSection(ArrayNodeDefinition $rootNode)
     {

--- a/src/DependencyInjection/JbPhumborExtension.php
+++ b/src/DependencyInjection/JbPhumborExtension.php
@@ -17,7 +17,7 @@ class JbPhumborExtension extends Extension
     /**
      * {@inheritDoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $config = $this->processConfiguration(new Configuration(), $configs);
         $this->loadConfiguration($container, $config);
@@ -32,7 +32,7 @@ class JbPhumborExtension extends Extension
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
      * @param array $config
      */
-    protected function loadConfiguration(ContainerBuilder $container, array $config)
+    protected function loadConfiguration(ContainerBuilder $container, array $config): void
     {
         $container->setParameter('env(THUMBOR_URL)', 'http://localhost:8888');
         $container->setParameter('env(THUMBOR_SECURITY_KEY)', '');

--- a/src/Transformer/BaseTransformer.php
+++ b/src/Transformer/BaseTransformer.php
@@ -33,7 +33,7 @@ class BaseTransformer
     /**
      * Phumbor Builder Factory
      *
-     * @var \Thumbor\Url\BuilderFactory
+     * @var BuilderFactory
      */
     protected $factory;
 
@@ -44,12 +44,6 @@ class BaseTransformer
      */
     protected $transformations;
 
-    /**
-     * Constructor
-     *
-     * @param \Thumbor\Url\BuilderFactory $factory
-     * @param array $transformations
-     */
     public function __construct(BuilderFactory $factory, array $transformations)
     {
         $this->factory = $factory;

--- a/src/Twig/PhumborExtension.php
+++ b/src/Twig/PhumborExtension.php
@@ -32,7 +32,7 @@ class PhumborExtension extends AbstractExtension
     /**
      * {@inheritDoc}
      */
-    public function getFilters()
+    public function getFilters(): array
     {
         return array(
             new TwigFilter('thumbor', array($this, 'transform')),
@@ -42,7 +42,7 @@ class PhumborExtension extends AbstractExtension
     /**
      * {@inheritDoc}
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return array(
             new TwigFunction('thumbor', array($this, 'transform')),


### PR DESCRIPTION
This adds a few return type hints where Symfony 5.4 triggers deprecation notices. 

I don't see the risk of BC breaks since there is no good reason to overwrite the methods affected. Adding types should even be compatible with PHP 7.0.