### PR TITLE
Upgrade to PHPUnit 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "symfony/config": "^5.4|^6.4|^7.3|^8.0",
         "symfony/dependency-injection": "^5.4|^6.4|^7.3|^8.0",
         "symfony/http-kernel": "^5.4|^6.4|^7.3|^8.0",
-        "twig/twig": "^2.0|^3.0",
+        "twig/twig": "^2.14.7|^3.0",
         "webfactory/phumbor": "^1.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,8 @@
         "webfactory/phumbor": "^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5.26|^9.5.20",
-        "symfony/yaml": "^5.4|^6.4|^7.3|^8.0",
-        "symfony/phpunit-bridge": ">=6.0"
+        "phpunit/phpunit": "^10.5.58",
+        "symfony/yaml": "^5.4|^6.4|^7.3|^8.0"
     },
     "autoload": {
         "psr-4": { "Jb\\Bundle\\PhumborBundle\\": "src" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">src</directory>
-    </include>
-  </coverage>
-  <testsuites>
-    <testsuite name="TestBundle Test Suite">
-      <directory>tests</directory>
-    </testsuite>
-  </testsuites>
-  <listeners>
-    <listener class="\Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-  </listeners>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    colors="true"
+    bootstrap="vendor/autoload.php"
+    cacheDirectory=".phpunit.cache"
+    displayDetailsOnAllIssues="true"
+    failOnAllIssues="true"
+>
+    <testsuites>
+        <testsuite name="TestBundle Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source ignoreSuppressionOfDeprecations="true">
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/Transformer/BaseTransformer.php
+++ b/src/Transformer/BaseTransformer.php
@@ -61,15 +61,15 @@ class BaseTransformer
      *
      * @throws \Jb\Bundle\PhumborBundle\Transformer\Exception\UnknownTransformationException
      */
-    public function transform($orig, $transformation = null, $overrides = array())
+    public function transform($orig, $transformation = null, $overrides = [])
     {
         $url = $this->factory->url($orig);
-        if (is_null($transformation) && count($overrides) == 0) {
+        if (!$overrides && null === $transformation) {
             return $url;
         }
 
         // Check if a transformation is given without overrides
-        if (!isset($this->transformations[$transformation]) && count($overrides) == 0) {
+        if (!$overrides && (null === $transformation || !isset($this->transformations[$transformation]))) {
             throw new Exception\UnknownTransformationException(
                 "Unknown transformation $transformation. Use on of "
                 . "the following ".implode(', ', array_keys($this->transformations))
@@ -77,9 +77,10 @@ class BaseTransformer
         }
 
         // Override transformation configuration with custom values
-        $configuration = array();
-        if (isset($this->transformations[$transformation])) {
+        if (null !== $transformation && isset($this->transformations[$transformation])) {
             $configuration = $this->transformations[$transformation];
+        } else {
+            $configuration = [];
         }
         $configuration = array_merge($configuration, $overrides);
 

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -3,6 +3,7 @@
 namespace Jb\Bundle\PhumborBundle\Tests\DependencyInjection;
 
 use Jb\Bundle\PhumborBundle\DependencyInjection\Configuration;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
@@ -17,7 +18,7 @@ class ConfigurationTest extends TestCase
     /**
      * Test the default configuration
      */
-    public function testDefaultConfig()
+    public function testDefaultConfig(): void
     {
         $processor = new Processor();
         $config = $processor->processConfiguration(new Configuration(), array());
@@ -31,7 +32,7 @@ class ConfigurationTest extends TestCase
     /**
      * Test the server configuration
      */
-    public function testServerConfiguration()
+    public function testServerConfiguration(): void
     {
         $processor = new Processor();
         $config = $processor->processConfiguration(new Configuration(), array(
@@ -47,7 +48,7 @@ class ConfigurationTest extends TestCase
         $this->assertEquals($config['server']['secret'], '123456789');
     }
 
-    public function testTransformationMerging()
+    public function testTransformationMerging(): void
     {
         // When a transformation is re-defined (overridden) in a later config file,
         // the newer definition entirely replaces the older one.
@@ -82,10 +83,8 @@ class ConfigurationTest extends TestCase
         ), $config['transformations']);
     }
 
-    /**
-     * @dataProvider getTransformationData
-     */
-    public function testTransformationConfiguration($transformationConfig, $processedTransformation)
+    #[DataProvider('getTransformationData')]
+    public function testTransformationConfiguration($transformationConfig, $processedTransformation): void
     {
         $processor = new Processor();
         $config = $processor->processConfiguration(new Configuration(), array(
@@ -99,7 +98,7 @@ class ConfigurationTest extends TestCase
         $this->assertEquals($config['transformations']['key'], $processedTransformation);
     }
 
-    public static function getTransformationData()
+    public static function getTransformationData(): array
     {
         return array(
             array(array('fit_in'=>array('width'=>10,'height'=>20)), array('fit_in'=>array('width'=>10,'height'=>20))),
@@ -136,10 +135,8 @@ class ConfigurationTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider getInvalidTypeData
-     */
-    public function testInvalidType($transformationData)
+    #[DataProvider('getInvalidTypeData')]
+    public function testInvalidType($transformationData): void
     {
         self::expectException(InvalidConfigurationException::class);
 
@@ -154,7 +151,7 @@ class ConfigurationTest extends TestCase
         ));
     }
 
-    public static function getInvalidTypeData()
+    public static function getInvalidTypeData(): array
     {
         return array(
             array( array('resize'=>array('width'=>'toto','height'=>10)) ),
@@ -173,7 +170,7 @@ class ConfigurationTest extends TestCase
      *
      * @return array
      */
-    protected static function getBundleDefaultConfig()
+    protected static function getBundleDefaultConfig(): array
     {
         return array(
             'server' => array(

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -99,7 +99,7 @@ class ConfigurationTest extends TestCase
         $this->assertEquals($config['transformations']['key'], $processedTransformation);
     }
 
-    public function getTransformationData()
+    public static function getTransformationData()
     {
         return array(
             array(array('fit_in'=>array('width'=>10,'height'=>20)), array('fit_in'=>array('width'=>10,'height'=>20))),
@@ -154,7 +154,7 @@ class ConfigurationTest extends TestCase
         ));
     }
 
-    public function getInvalidTypeData($transformationData)
+    public static function getInvalidTypeData()
     {
         return array(
             array( array('resize'=>array('width'=>'toto','height'=>10)) ),

--- a/tests/DependencyInjection/JbPhumborExtensionTestCase.php
+++ b/tests/DependencyInjection/JbPhumborExtensionTestCase.php
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
  *
  * @author Jonathan Bouzekri <jonathan.bouzekri@gmail.com>
  */
-abstract class JbPhumborExtensionTest extends TestCase
+abstract class JbPhumborExtensionTestCase extends TestCase
 {
     /**
      * Defined in children class

--- a/tests/DependencyInjection/JbPhumborExtensionTestCase.php
+++ b/tests/DependencyInjection/JbPhumborExtensionTestCase.php
@@ -23,7 +23,7 @@ abstract class JbPhumborExtensionTestCase extends TestCase
      */
     abstract protected function loadFromFile(ContainerBuilder $container, $file);
 
-    public function testLoading()
+    public function testLoading(): void
     {
         $container = $this->createContainerFromFile('transformers');
 
@@ -41,7 +41,7 @@ abstract class JbPhumborExtensionTestCase extends TestCase
      * @param array $data
      * @return \Symfony\Component\DependencyInjection\ContainerBuilder
      */
-    protected function createContainer(array $data = array())
+    protected function createContainer(array $data = array()): ContainerBuilder
     {
         return new ContainerBuilder(new ParameterBag(array_merge(array(
             'kernel.bundles'     => array('JbPhumborBundle' => 'Jb\\Bundle\\PhumborBundle\\JbPhumborBundle'),
@@ -62,7 +62,7 @@ abstract class JbPhumborExtensionTestCase extends TestCase
      *
      * @return \Symfony\Component\DependencyInjection\ContainerBuilder
      */
-    protected function createContainerFromFile($file, $data = array())
+    protected function createContainerFromFile($file, $data = array()): ContainerBuilder
     {
         $container = $this->createContainer($data);
         $container->registerExtension(new JbPhumborExtension());

--- a/tests/DependencyInjection/YamlJbPhumborExtensionTest.php
+++ b/tests/DependencyInjection/YamlJbPhumborExtensionTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\Config\FileLocator;
  *
  * @author Jonathan Bouzekri <jonathan.bouzekri@gmail.com>
  */
-class YamlJbPhumborExtensionTest extends JbPhumborExtensionTest
+class YamlJbPhumborExtensionTest extends JbPhumborExtensionTestCase
 {
     protected function loadFromFile(ContainerBuilder $container, $file)
     {

--- a/tests/Transformer/BaseTransformerTest.php
+++ b/tests/Transformer/BaseTransformerTest.php
@@ -43,7 +43,7 @@ class BaseTransformerTest extends TestCase
     /**
      * Test without transformation
      */
-    public function testEmptyTransformation()
+    public function testEmptyTransformation(): void
     {
         $transformedUrl = $this->transformer->transform('http://phumbor.jb.fr/logo.png', null);
         $buildedUrl = $this->factory->url('http://phumbor.jb.fr/logo.png');
@@ -54,7 +54,7 @@ class BaseTransformerTest extends TestCase
     /**
      * Test normal transformation
      */
-    public function testNormalTransformation()
+    public function testNormalTransformation(): void
     {
         $transformedUrl = $this->transformer->transform('http://phumbor.jb.fr/logo.png', 'width_50');
         $buildedUrl = $this->factory->url('http://phumbor.jb.fr/logo.png')->resize(50, 0);
@@ -62,7 +62,7 @@ class BaseTransformerTest extends TestCase
         $this->assertEquals($transformedUrl, $buildedUrl);
     }
 
-    public function testUnknownTransformationException()
+    public function testUnknownTransformationException(): void
     {
         self::expectException(UnknownTransformationException::class);
         $transformedUrl = $this->transformer->transform('http://phumbor.jb.fr/logo.png', 'not_known');
@@ -74,7 +74,7 @@ class BaseTransformerTest extends TestCase
     /**
      * Test override transformation
      */
-    public function testOverrideTransformation()
+    public function testOverrideTransformation(): void
     {
         $transformedUrl = $this->transformer->transform(
             'http://phumbor.jb.fr/logo.png',
@@ -89,7 +89,7 @@ class BaseTransformerTest extends TestCase
     /**
      * Test multiple transformation
      */
-    public function testMultipleTransformation()
+    public function testMultipleTransformation(): void
     {
         $transformedUrl = $this->transformer->transform(
             'http://phumbor.jb.fr/logo.png',
@@ -107,7 +107,7 @@ class BaseTransformerTest extends TestCase
     /**
      * Test trim without color
      */
-    public function testTrimWithoutColor()
+    public function testTrimWithoutColor(): void
     {
         $transformedUrl = $this->transformer->transform('http://phumbor.jb.fr/logo.png', null, array('trim'=>false));
         $buildedUrl = $this->factory->url('http://phumbor.jb.fr/logo.png')->trim(false);
@@ -118,7 +118,7 @@ class BaseTransformerTest extends TestCase
     /**
      * Test trim with color
      */
-    public function testTrimWithColor()
+    public function testTrimWithColor(): void
     {
         $transformedUrl = $this->transformer->transform('http://phumbor.jb.fr/logo.png', null, array('trim'=>'color'));
         $buildedUrl = $this->factory->url('http://phumbor.jb.fr/logo.png')->trim('color');
@@ -129,7 +129,7 @@ class BaseTransformerTest extends TestCase
     /**
      * Test crop
      */
-    public function testCrop()
+    public function testCrop(): void
     {
         $transformedUrl = $this->transformer->transform(
             'http://phumbor.jb.fr/logo.png',
@@ -144,7 +144,7 @@ class BaseTransformerTest extends TestCase
     /**
      * Test crop
      */
-    public function testResize()
+    public function testResize(): void
     {
         $transformedUrl = $this->transformer->transform(
             'http://phumbor.jb.fr/logo.png',
@@ -159,7 +159,7 @@ class BaseTransformerTest extends TestCase
     /**
      * Test crop
      */
-    public function testFitIn()
+    public function testFitIn(): void
     {
         $transformedUrl = $this->transformer->transform(
             'http://phumbor.jb.fr/logo.png',
@@ -174,7 +174,7 @@ class BaseTransformerTest extends TestCase
     /**
      * Test fullFitIn
      */
-    public function testFullFitIn()
+    public function testFullFitIn(): void
     {
         $transformedUrl = $this->transformer->transform(
             'http://phumbor.jb.fr/logo.png',
@@ -189,7 +189,7 @@ class BaseTransformerTest extends TestCase
     /**
      * Test halign
      */
-    public function testHalign()
+    public function testHalign(): void
     {
         $transformedUrl = $this->transformer->transform(
             'http://phumbor.jb.fr/logo.png',
@@ -204,7 +204,7 @@ class BaseTransformerTest extends TestCase
     /**
      * Test valign
      */
-    public function testValign()
+    public function testValign(): void
     {
         $transformedUrl = $this->transformer->transform(
             'http://phumbor.jb.fr/logo.png',
@@ -219,7 +219,7 @@ class BaseTransformerTest extends TestCase
     /**
      * Test smartCrop
      */
-    public function testSmartCrop()
+    public function testSmartCrop(): void
     {
         $transformedUrl = $this->transformer->transform(
             'http://phumbor.jb.fr/logo.png',
@@ -234,7 +234,7 @@ class BaseTransformerTest extends TestCase
     /**
      * Test metadataOnly
      */
-    public function testMetadataOnly()
+    public function testMetadataOnly(): void
     {
         $transformedUrl = $this->transformer->transform(
             'http://phumbor.jb.fr/logo.png',
@@ -249,7 +249,7 @@ class BaseTransformerTest extends TestCase
     /**
      * Test filters
      */
-    public function testFilters()
+    public function testFilters(): void
     {
         $transformedUrl = $this->transformer->transform(
             'http://phumbor.jb.fr/logo.png',
@@ -275,7 +275,7 @@ class BaseTransformerTest extends TestCase
     /**
      * Test setFactory
      */
-    public function testSetFactory()
+    public function testSetFactory(): void
     {
         $overrideFactory = new BuilderFactory('http://mynewhostname', '123456799');
         $this->transformer->setFactory($overrideFactory);

--- a/tests/Twig/PhumborExtensionTest.php
+++ b/tests/Twig/PhumborExtensionTest.php
@@ -44,7 +44,7 @@ class PhumborExtensionTest extends TestCase
     /**
      * Test twig getFilters
      */
-    public function testGetFilters()
+    public function testGetFilters(): void
     {
         $this->assertEquals(count($this->extension->getFilters()), 1);
     }
@@ -52,7 +52,7 @@ class PhumborExtensionTest extends TestCase
     /**
      * Test twig getFunctions
      */
-    public function testGetFunctions()
+    public function testGetFunctions(): void
     {
         $this->assertEquals(count($this->extension->getFunctions()), 1);
     }
@@ -60,7 +60,7 @@ class PhumborExtensionTest extends TestCase
     /**
      * Test twig get filters
      */
-    public function testTransform()
+    public function testTransform(): void
     {
         $transformedUrl = $this->extension->transform('logo.png', 'width_50');
         $builtUrl = $this->factory->url('logo.png')->resize(50, 0);


### PR DESCRIPTION
:warning: This PR is stacked on top of https://github.com/jbouzekri/PhumborBundle/pull/27 - merge the other one first.

This updates PHPUnit to version 10, the lowest version that is still compatible with PHP 8.1.